### PR TITLE
feat: qr-code scan issue #41

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^17.0.1",
     "react-i18next": "^11.8.10",
     "react-moment": "^1.1.1",
+    "react-qr-reader": "^2.2.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.2",
@@ -77,5 +78,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "devDependencies": {
+    "@types/react-qr-reader": "^2.1.3"
   }
 }

--- a/src/assets/i18n/de/translation.json
+++ b/src/assets/i18n/de/translation.json
@@ -47,6 +47,8 @@
   "unknown-process-number":"Unbekannte Vorgangsnummer: {{processNo}}",
   "server-error":"Datenübermittlungsfehler: {{status}}",
   "server-not-reachable": "Server unerreichbar",
-  "connection-error": "Verbindungsfehler: {{message}}"
-
+  "connection-error": "Verbindungsfehler: {{message}}",
+  "qr-scan": "QR-Code scan",
+  "qr-scan-https-only" : "QR-Scan braucht eine HTTPS Verbindung",
+  "qr-code-no-patient-data": "QR-code enthält keine Patientendaten"
 }

--- a/src/assets/i18n/en/translation.json
+++ b/src/assets/i18n/en/translation.json
@@ -46,5 +46,8 @@
   "unknown-process-number":"Unknown process number: {{processNo}}",
   "server-error":"server error: {{status}}",
   "server-not-reachable": "server not reachable",
-  "connection-error": "connection error: {{message}}"
+  "connection-error": "connection error: {{message}}",
+  "qr-scan": "QR-Code scan",
+  "qr-scan-https-only" : "QR-Scan will work only with https",
+  "qr-code-no-patient-data": "QR-code does not contain patient data"
 }

--- a/src/components/qr-scan.component.tsx
+++ b/src/components/qr-scan.component.tsx
@@ -20,7 +20,7 @@
  */
 
 import React from 'react';
-import { Button, Card, Col, Form, Row } from 'react-bootstrap'
+import { Button, Card, Col, Row } from 'react-bootstrap'
 import QrReader from 'react-qr-reader'
 import { v4 as uuid } from 'uuid';
 
@@ -29,7 +29,7 @@ import { useTranslation } from 'react-i18next';
 
 import useNavigation from '../misc/navigation';
 
-const RecordTestResult = (props: any) => {
+const QrScan = (props: any) => {
 
     const navigation = useNavigation();
     const { t } = useTranslation();
@@ -128,4 +128,4 @@ const RecordTestResult = (props: any) => {
     )
 }
 
-export default RecordTestResult;
+export default QrScan;

--- a/src/components/qr-scan.component.tsx
+++ b/src/components/qr-scan.component.tsx
@@ -1,0 +1,131 @@
+/*
+ * Corona-Warn-App / cwa-quick-test-frontend
+ *
+ * (C) 2021, T-Systems International GmbH
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { Button, Card, Col, Form, Row } from 'react-bootstrap'
+import QrReader from 'react-qr-reader'
+import { v4 as uuid } from 'uuid';
+
+import '../i18n';
+import { useTranslation } from 'react-i18next';
+
+import useNavigation from '../misc/navigation';
+
+const RecordTestResult = (props: any) => {
+
+    const navigation = useNavigation();
+    const { t } = useTranslation();
+
+    const [message, setMessage] = React.useState('');
+   
+    const handleScan = (data: string | null) => {
+        if (props.setPatient && data) {
+            try {
+                const scanData = JSON.parse(data);
+                if (!scanData.name) {
+                    setMessage(t('translation:qr-code-no-patient-data'));
+                } else {
+                    const patientData = {
+                        name: scanData.name ? scanData.name : '',
+                        firstName: scanData.firstName ? scanData.firstName : '',
+                        // need to be real date object to work
+                        dateOfBirth: scanData.dateOfBirth ? Date.parse(scanData.dateOfBirth) : null,
+                        sex: scanData.sex,
+                        zip: scanData.zip,
+                        city: scanData.city,
+                        street: scanData.street,
+                        houseNumber: scanData.houseNumber,
+                        phoneNumber: scanData.phoneNumber,
+                        emailAddress: scanData.emailAddress,
+                        // TODO patient record component need uuId to run
+                        uuId: uuid()
+                    }
+                    props.setPatient(patientData);
+                    setMessage(JSON.stringify(patientData));
+                    navigation.toRecordPatient();
+                }
+            } catch (e) {
+                setMessage(t('translation:qr-code-no-patient-data'));
+            }
+        }
+    }
+
+    const handleError = (error: any) => {
+        if (window.location.protocol == 'http:') {
+            setMessage(t('translation:qr-scan-https-only'));
+        } else {
+            setMessage("Scan Error: "+error);
+        }
+    }
+
+    var messageHtml = undefined;
+    if (message.length > 0) {
+        messageHtml = <div className="alert alert-warning">
+            {message}
+        </div>;
+    }
+
+    return (
+        <>
+            <Card id='data-card'>
+                <Card.Header id='data-header' className='pb-0'>
+                    <Row>
+                        <Col md='6'>
+                            <Card.Title className='m-0 jcc-xs-jcfs-md' as={'h2'} >{t('translation:qr-scan')}</Card.Title>
+                        </Col>
+                    </Row>
+                    <hr />
+                </Card.Header>
+
+                {/*
+    content area with process number input and radios
+    */}
+                <Card.Body id='data-body' className='pt-0'>
+                    <QrReader
+                        delay={300}
+                        onScan={handleScan}
+                        onError={handleError}
+                    />
+                    {messageHtml}
+                </Card.Body>
+
+                {/*
+    footer with cancel and submit button
+    */}
+                <Card.Footer id='data-footer'>
+                    <Row>
+                        <Col sm='6' md='3'>
+                            <Button
+                                className='my-1 my-md-0 p-0'
+                                block
+                                onClick={navigation.toLanding}
+                           >
+                                {t('translation:cancel')}
+                            </Button>
+                        </Col>
+                    </Row>
+                </Card.Footer>
+            </Card>
+        </>
+    )
+}
+
+export default RecordTestResult;

--- a/src/routing.component.tsx
+++ b/src/routing.component.tsx
@@ -35,6 +35,7 @@ import LandingPage from './components/landing-page.component';
 import RecordPatientData from './components/record-patient-data.component';
 import ShowPatientData from './components/show-patient-data.component';
 import RecordTestResult from './components/record-test-result.component';
+import QrScan from './components/qr-scan.component';
 import PrivateRoute from './components/private-route.component';
 
 const Routing = (props: any) => {
@@ -85,7 +86,7 @@ const Routing = (props: any) => {
                 {/* QR Scan */}
                 <Route exact path={routes.qrScan}>
                     {/* <QRScan /> */}
-                    <LandingPage />
+                    <QrScan setPatient={setPatient}/>
                 </Route>
 
                 {/* Show QR Scan Data */}


### PR DESCRIPTION
add new component for qr-code-scan
It uses new dependency react-qr-reader (You will need npm install)
The qr scan works only on mobile and https connection (see https://www.npmjs.com/package/react-qr-reader).
I have tested it on android
The functionality expect the same data structure as generated by the app itself.
(So the old test qr-code can be reused this way)
After successfull scan the app navigate automatically to patient record page (with filled data from scan)
