### PR TITLE
Remove untrue statement from README.md (log-upload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from [Apple](https://www.apple.com/covid19/contacttracing/)
 and [Google](https://www.google.com/covid19/exposurenotifications/). The apps (for both iOS and Android) use Bluetooth
 technology to exchange anonymous encrypted data with other mobile phones (on which the app is also installed) in the
 vicinity of an app user's phone. The data is stored locally on each user's device, preventing authorities or other
-parties from accessing or controlling the data. This repository contains the **log upload** for the Corona-Warn-App.
+parties from accessing or controlling the data.
 
 ## Status
 


### PR DESCRIPTION
This PR removes the information that this repository contains the log-upload part of the Corona-Warn-App, since this is repository doesn't contain the log-upload part, from the README.md.