### PR TITLE
Sanitize qr-code VCARD input to match regex field specifications (see #187)

### DIFF
--- a/src/misc/qr-code-value.tsx
+++ b/src/misc/qr-code-value.tsx
@@ -136,21 +136,21 @@ export const getPersonDataFromScan = (data: string | null) => {
                 const em = s.email.find((ema) => ema.value !== '');
                 result = {
                     personData: {
-                        familyName: s.name.surname,
-                        givenName: s.name.name,
+                        familyName: s.name.surname.trim(),
+                        givenName: s.name.name.trim(),
                         standardisedGivenName: '',
                         standardisedFamilyName: '',
                         dateOfBirth: s.birthday ? new Date(s.birthday) : undefined,
                         sex: undefined
                     },
                     addressData: {
-                        zip: s.address[0].value.postalCode,
-                        city: s.address[0].value.city,
-                        street: s.address[0].value.street,
-                        houseNumber: s.address[0].value.number
+                        zip: s.address[0].value.postalCode.trim(),
+                        city: s.address[0].value.city.trim(),
+                        street: s.address[0].value.street.trim(),
+                        houseNumber: s.address[0].value.number.trim()
                     },
-                    phoneNumber: ph ? ph.value : undefined,
-                    emailAddress: em ? em.value : undefined,
+                    phoneNumber: ph ? ph.value.replace(/\s/g,'') : undefined,
+                    emailAddress: em ? em.value.trim() : undefined,
                 }
             }
         } catch (e) {


### PR DESCRIPTION
This commit sanitizes the qr-code input from "Schnelltest-Profil". Many users are adding spaces on fields where this app does not allow them to be. By sanitizing the input we allow not experienced users to still use the quick-test-frontend (see #187)