### PR TITLE
fix: dcc consent translation german

### DIFF
--- a/src/assets/i18n/de/translation.json
+++ b/src/assets/i18n/de/translation.json
@@ -79,5 +79,6 @@
   "testId-input-header": "Eingabe Proben-ID",
   "error-processId-data-load": "Die eingegebene Proben-ID ist uns nicht bekannt!",
   "ok":"OK",
-  "change-password":"Passwort ändern"
+  "change-password":"Passwort ändern",
+  "dccConsent":"Patient wünscht ein offizielles COVID-Testzertifikat der EU (DCC)."
 }


### PR DESCRIPTION
Adding german translation for dcc consent, that is asked upon test registration.