### PR TITLE
fix: revert set portal email to required

### DIFF
--- a/src/components/modals/group-modal.component.tsx
+++ b/src/components/modals/group-modal.component.tsx
@@ -341,7 +341,6 @@ const GroupModal = (props: any) => {
                                             props.resetError();
                                         }}
                                         type='email'
-                                        required={group.searchPortalConsent}
                                         pattern={utils.pattern.eMail}
                                         minLength={5}
                                         maxLength={255}


### PR DESCRIPTION
Reverts corona-warn-app/cwa-quick-test-frontend#262
email field should be kept optional in order to not force the Teststellen provider to provide it.