### PR TITLE
set facing mode to environment

### DIFF
--- a/src/components/qr-scan.component.tsx
+++ b/src/components/qr-scan.component.tsx
@@ -95,7 +95,7 @@ const QrScan = (props: any) => {
           className='pt-0'
         >
           <QrReader
-            constraints={{}}
+            constraints={{ facingMode: 'environment' }}
             scanDelay={300}
             onResult={handleScanResult}
           />


### PR DESCRIPTION
- prevent front facing camera to be pre-selected during QR Code scan